### PR TITLE
Add page navigation

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -2,7 +2,7 @@ import { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
   appId: 'io.ionic.starter',
-  appName: 'blank',
+  appName: 'electionReminders',
   webDir: 'dist',
   server: {
     androidScheme: 'https'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import '@ionic/react/css/display.css';
 
 /* Theme variables */
 import './theme/variables.css';
+import MyReminders from './pages/MyReminders';
 
 setupIonicReact();
 
@@ -28,12 +29,11 @@ const App: React.FC = () => (
   <IonApp>
     <IonReactRouter>
       <IonRouterOutlet>
-        <Route exact path="/home">
-          <Home />
-        </Route>
+        <Route exact path="/home" component={Home} />
         <Route exact path="/">
           <Redirect to="/home" />
         </Route>
+        <Route exact path="/myReminders" component={MyReminders} />
       </IonRouterOutlet>
     </IonReactRouter>
   </IonApp>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import '@ionic/react/css/display.css';
 /* Theme variables */
 import './theme/variables.css';
 import MyReminders from './pages/MyReminders';
+import CountryElections from './components/CountryElections';
 
 setupIonicReact();
 
@@ -34,6 +35,7 @@ const App: React.FC = () => (
           <Redirect to="/home" />
         </Route>
         <Route exact path="/myReminders" component={MyReminders} />
+        <Route exact path="/countryElections/:countryName" component={CountryElections} />
       </IonRouterOutlet>
     </IonReactRouter>
   </IonApp>

--- a/src/components/CountryElections.tsx
+++ b/src/components/CountryElections.tsx
@@ -1,0 +1,20 @@
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
+import React from 'react';
+
+const CountryElections: React.FC = () => {
+
+    return (
+        <IonPage>
+            <IonHeader>
+                <IonToolbar>
+                    <IonTitle>Country Elections</IonTitle>
+                </IonToolbar>
+            </IonHeader>
+            <IonContent className="ion-padding">
+                Country Elections
+            </IonContent>
+        </IonPage>
+    );
+};
+
+export default CountryElections;

--- a/src/components/CountrySearchBar.tsx
+++ b/src/components/CountrySearchBar.tsx
@@ -8,6 +8,8 @@ interface ContainerProps { }
 const CountrySearchBar: React.FC<ContainerProps> = () => {
 
     const initialData: SearchResult[] = [],
+        debounceTimeInMilliseconds = 300,
+        searchBarPlaceholder = "Enter country name here",
         [searchTerm, setSearchTerm] = useState(""),
         [results, setResults] = useState(initialData);
 
@@ -27,8 +29,8 @@ const CountrySearchBar: React.FC<ContainerProps> = () => {
                 onIonChange={(e) => setSearchTerm(e.detail.value!)}
                 showClearButton="always"
                 animated={true}
-                placeholder="Enter country name here"
-                debounce={300}
+                placeholder={searchBarPlaceholder}
+                debounce={debounceTimeInMilliseconds}
             ></IonSearchbar >
 
             <IonList>

--- a/src/components/CountrySearchBar.tsx
+++ b/src/components/CountrySearchBar.tsx
@@ -1,34 +1,44 @@
 import './CountrySearchBar.css';
-import { IonSearchbar, IonList, IonItem } from '@ionic/react';
-import React, { useState } from 'react';
-
+import { IonSearchbar, IonList, IonItem, IonLabel, IonIcon } from '@ionic/react';
+import React, { useState, useEffect } from 'react';
+import { useDummyApi, SearchResult } from '../hooks/useDummyApi';
+import { checkboxOutline } from "ionicons/icons"
 interface ContainerProps { }
 
 const CountrySearchBar: React.FC<ContainerProps> = () => {
-    const data = [
-        'Germany',
-        'EU'
-    ], [results, setResults] = useState([...data]);
 
+    const initialData: SearchResult[] = [],
+        [searchTerm, setSearchTerm] = useState(""),
+        [results, setResults] = useState(initialData);
 
-    const handleInput = (ev: Event) => {
-        let query = '';
-        const target = ev.target as HTMLIonSearchbarElement;
-        if (target) query = target.value!.toLowerCase();
-
-        setResults(data.filter((d) => d.toLowerCase().indexOf(query) > -1));
-    };
+    useEffect(() => {
+        if (searchTerm === "") {
+            setResults([]);
+            return;
+        }
+        const data: SearchResult[] = useDummyApi();
+        setResults(data);
+    }, [searchTerm]);
 
     return (
         <>
-            <IonSearchbar showClearButton="always" animated={true} placeholder="Enter country name here" onIonInput={(ev) => handleInput(ev)}
-            ></IonSearchbar>
+            <IonSearchbar
+                value={searchTerm}
+                onIonChange={(e) => setSearchTerm(e.detail.value!)}
+                showClearButton="always"
+                animated={true}
+                placeholder="Enter country name here"
+                debounce={300}
+            ></IonSearchbar >
 
             <IonList>
-                {results.map((result) => (
-                    <IonItem>{result}</IonItem>
+                {results.map((result: SearchResult) => (
+                    <IonItem key={result.Name} routerLink={`/countryElections/${result.Name}`}>
+                        <IonLabel> {result.Name}</IonLabel>
+                        <IonIcon slot="end" icon={checkboxOutline} />
+                    </IonItem>
                 ))}
-            </IonList>
+            </IonList >
         </>
     );
 };

--- a/src/hooks/useDummyApi.tsx
+++ b/src/hooks/useDummyApi.tsx
@@ -1,0 +1,9 @@
+export interface SearchResult {
+    Name: String
+}
+
+export const useDummyApi = () => {
+    const data = [{ Name: "EU" }, { Name: "Germany" }];
+    return data;
+}
+

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,7 +12,7 @@ const Home: React.FC = () => {
         <IonToolbar>
           <IonTitle>Election Reminders</IonTitle>
           <IonButtons slot="primary">
-            <IonButton>My Reminders</IonButton>
+            <IonButton href='myReminders'>My Reminders</IonButton>
           </IonButtons>
         </IonToolbar>
       </IonHeader>

--- a/src/pages/MyReminders.tsx
+++ b/src/pages/MyReminders.tsx
@@ -1,0 +1,20 @@
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
+import React from 'react';
+
+const MyReminders: React.FC = () => {
+
+    return (
+        <IonPage>
+            <IonHeader>
+                <IonToolbar>
+                    <IonTitle>My Reminders</IonTitle>
+                </IonToolbar>
+            </IonHeader>
+            <IonContent className="ion-padding">
+                UI goes here...
+            </IonContent>
+        </IonPage>
+    );
+};
+
+export default MyReminders;


### PR DESCRIPTION
![image](https://github.com/PhilipWright96/ElectionReminders/assets/49524546/ae83b9be-b53f-49ec-8a2d-577504566ad2)

This MR adds basic navigation to the app. For example, if you click on the My Reminders button, you go to a My Reminders page. There is also a search bar with two hardcoded options - and if you press a option, you go to a country elections component